### PR TITLE
Refactor PDF to Markdown converter for multiple AI providers

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,2 @@
 ANTHROPIC_API_KEY=<enter your key here>
+OPENAI_API_KEY=<enter your key here>

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ env/
 # files to process for development
 /input
 /output
+notes.md

--- a/notes.md
+++ b/notes.md
@@ -1,2 +1,0 @@
-
-- [Github Environments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)

--- a/pdf_to_md_llm/__init__.py
+++ b/pdf_to_md_llm/__init__.py
@@ -1,8 +1,8 @@
 """
-PDF to Markdown Converter using Claude API
+PDF to Markdown Converter using AI providers
 
 A tool to convert PDF documents to clean, well-structured Markdown
-using LLM-assisted processing.
+using LLM-assisted processing with support for multiple AI providers.
 """
 
 from .converter import (
@@ -10,18 +10,30 @@ from .converter import (
     batch_convert,
     extract_text_from_pdf,
     chunk_pages,
+    DEFAULT_PROVIDER,
     DEFAULT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PAGES_PER_CHUNK,
 )
+from .providers import (
+    AIProvider,
+    AnthropicProvider,
+    OpenAIProvider,
+    get_provider,
+)
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = [
     "convert_pdf_to_markdown",
     "batch_convert",
     "extract_text_from_pdf",
     "chunk_pages",
+    "DEFAULT_PROVIDER",
     "DEFAULT_MODEL",
     "DEFAULT_MAX_TOKENS",
     "DEFAULT_PAGES_PER_CHUNK",
+    "AIProvider",
+    "AnthropicProvider",
+    "OpenAIProvider",
+    "get_provider",
 ]

--- a/pdf_to_md_llm/cli.py
+++ b/pdf_to_md_llm/cli.py
@@ -9,7 +9,8 @@ from dotenv import load_dotenv
 from .converter import (
     convert_pdf_to_markdown,
     batch_convert,
-    DEFAULT_PAGES_PER_CHUNK
+    DEFAULT_PAGES_PER_CHUNK,
+    DEFAULT_PROVIDER
 )
 
 # Load environment variables from .env file
@@ -21,15 +22,14 @@ load_dotenv()
 def cli(ctx):
     """PDF to Markdown Converter (LLM-Assisted)
 
-    Convert PDF documents to clean, well-structured Markdown using Claude API.
-    """
-    # Check for API key
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if api_key == "your-api-key-here" or not api_key:
-        click.echo("Error: Please set ANTHROPIC_API_KEY environment variable", err=True)
-        click.echo("  export ANTHROPIC_API_KEY='your-key-here'", err=True)
-        ctx.exit(1)
+    Convert PDF documents to clean, well-structured Markdown using AI providers.
 
+    Supported providers: anthropic (Claude), openai (GPT)
+
+    Set the appropriate API key environment variable:
+    - ANTHROPIC_API_KEY for Anthropic/Claude
+    - OPENAI_API_KEY for OpenAI/GPT
+    """
     # If no subcommand is provided, show help
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -38,31 +38,57 @@ def cli(ctx):
 @cli.command()
 @click.argument('pdf_file', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_file', type=click.Path(), required=False)
+@click.option('--provider', default=DEFAULT_PROVIDER, type=click.Choice(['anthropic', 'openai'], case_sensitive=False),
+              help=f'AI provider to use (default: {DEFAULT_PROVIDER})')
+@click.option('--model', default=None, type=str,
+              help='Model to use (optional, uses provider defaults if not specified)')
+@click.option('--api-key', default=None, type=str,
+              help='API key for the provider (optional, uses environment variable if not specified)')
 @click.option('--pages-per-chunk', default=DEFAULT_PAGES_PER_CHUNK, type=int,
               help=f'Number of pages to process per API call (default: {DEFAULT_PAGES_PER_CHUNK})')
-def convert(pdf_file, output_file, pages_per_chunk):
+def convert(pdf_file, output_file, provider, model, api_key, pages_per_chunk):
     """Convert a single PDF file to markdown.
 
     PDF_FILE: Path to the PDF file to convert
 
     OUTPUT_FILE: Optional output path (defaults to same name with .md extension)
     """
-    convert_pdf_to_markdown(pdf_file, output_file, pages_per_chunk)
+    convert_pdf_to_markdown(
+        pdf_file,
+        output_file,
+        pages_per_chunk=pages_per_chunk,
+        provider=provider.lower(),
+        api_key=api_key,
+        model=model
+    )
 
 
 @cli.command()
 @click.argument('input_folder', type=click.Path(exists=True, file_okay=False))
 @click.argument('output_folder', type=click.Path(), required=False)
+@click.option('--provider', default=DEFAULT_PROVIDER, type=click.Choice(['anthropic', 'openai'], case_sensitive=False),
+              help=f'AI provider to use (default: {DEFAULT_PROVIDER})')
+@click.option('--model', default=None, type=str,
+              help='Model to use (optional, uses provider defaults if not specified)')
+@click.option('--api-key', default=None, type=str,
+              help='API key for the provider (optional, uses environment variable if not specified)')
 @click.option('--pages-per-chunk', default=DEFAULT_PAGES_PER_CHUNK, type=int,
               help=f'Number of pages to process per API call (default: {DEFAULT_PAGES_PER_CHUNK})')
-def batch(input_folder, output_folder, pages_per_chunk):
+def batch(input_folder, output_folder, provider, model, api_key, pages_per_chunk):
     """Convert all PDF files in a folder to markdown.
 
     INPUT_FOLDER: Folder containing PDF files
 
     OUTPUT_FOLDER: Optional output folder (defaults to same as input)
     """
-    batch_convert(input_folder, output_folder, pages_per_chunk)
+    batch_convert(
+        input_folder,
+        output_folder,
+        pages_per_chunk=pages_per_chunk,
+        provider=provider.lower(),
+        api_key=api_key,
+        model=model
+    )
 
 
 if __name__ == "__main__":

--- a/pdf_to_md_llm/providers.py
+++ b/pdf_to_md_llm/providers.py
@@ -1,0 +1,189 @@
+"""
+AI provider abstraction for PDF to Markdown conversion
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+import os
+
+
+class AIProvider(ABC):
+    """Abstract base class for AI providers"""
+
+    @abstractmethod
+    def convert_to_markdown(self, text: str, max_tokens: int) -> str:
+        """
+        Convert text to markdown using the AI provider.
+
+        Args:
+            text: Text to convert
+            max_tokens: Maximum tokens for response
+
+        Returns:
+            Converted markdown text
+        """
+        pass
+
+    @abstractmethod
+    def validate_config(self) -> bool:
+        """
+        Validate that the provider is properly configured.
+
+        Returns:
+            True if valid, False otherwise
+        """
+        pass
+
+
+class AnthropicProvider(AIProvider):
+    """Anthropic (Claude) AI provider"""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "claude-sonnet-4-20250514"
+    ):
+        """
+        Initialize Anthropic provider.
+
+        Args:
+            api_key: Anthropic API key (defaults to ANTHROPIC_API_KEY env var)
+            model: Model to use
+        """
+        import anthropic
+
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        self.model = model
+        self.client = anthropic.Anthropic(api_key=self.api_key)
+
+    def convert_to_markdown(self, text: str, max_tokens: int) -> str:
+        """Convert text to markdown using Claude API"""
+        prompt = f"""Convert this text from a PDF document to clean, well-structured markdown.
+
+Requirements:
+- Use proper heading hierarchy (# for main titles, ## for sections, ### for subsections)
+- Convert any tables to proper markdown table format with aligned columns
+- Convert tables to structured headings instead of markdown tables if they are complex
+- Watch out for tables that span multiple pages - treat them as one table
+- Clean up formatting artifacts from PDF extraction (broken lines, weird spacing)
+- Use consistent bullet points and numbered lists
+- Preserve all information - don't summarize or omit content
+- ALWAYS Remove page numbers, headers, and footers if they appear
+- Make the document scannable with clear structure
+
+Output ONLY the markdown - no explanations or commentary.
+
+Text to convert:
+
+{text}"""
+
+        message = self.client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            messages=[{
+                "role": "user",
+                "content": prompt
+            }]
+        )
+
+        return message.content[0].text
+
+    def validate_config(self) -> bool:
+        """Validate Anthropic API key"""
+        return bool(self.api_key and self.api_key != "your-api-key-here")
+
+
+class OpenAIProvider(AIProvider):
+    """OpenAI (GPT) AI provider"""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4o"
+    ):
+        """
+        Initialize OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key (defaults to OPENAI_API_KEY env var)
+            model: Model to use (e.g., gpt-4o, gpt-4-turbo, gpt-3.5-turbo)
+        """
+        from openai import OpenAI
+
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self.model = model
+        self.client = OpenAI(api_key=self.api_key)
+
+    def convert_to_markdown(self, text: str, max_tokens: int) -> str:
+        """Convert text to markdown using OpenAI API"""
+        prompt = f"""Convert this text from a PDF document to clean, well-structured markdown.
+
+Requirements:
+- Use proper heading hierarchy (# for main titles, ## for sections, ### for subsections)
+- Convert any tables to proper markdown table format with aligned columns
+- Convert tables to structured headings instead of markdown tables if they are complex
+- Watch out for tables that span multiple pages - treat them as one table
+- Clean up formatting artifacts from PDF extraction (broken lines, weird spacing)
+- Use consistent bullet points and numbered lists
+- Preserve all information - don't summarize or omit content
+- ALWAYS Remove page numbers, headers, and footers if they appear
+- Make the document scannable with clear structure
+
+Output ONLY the markdown - no explanations or commentary.
+
+Text to convert:
+
+{text}"""
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            messages=[{
+                "role": "user",
+                "content": prompt
+            }]
+        )
+
+        return response.choices[0].message.content
+
+    def validate_config(self) -> bool:
+        """Validate OpenAI API key"""
+        return bool(self.api_key and self.api_key != "your-api-key-here")
+
+
+def get_provider(
+    provider_name: str,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None
+) -> AIProvider:
+    """
+    Factory function to get an AI provider by name.
+
+    Args:
+        provider_name: Name of the provider ('anthropic' or 'openai')
+        api_key: API key for the provider
+        model: Model to use (optional, uses provider defaults if not specified)
+
+    Returns:
+        AIProvider instance
+
+    Raises:
+        ValueError: If provider name is not recognized
+    """
+    provider_name = provider_name.lower()
+
+    if provider_name == "anthropic":
+        kwargs = {"api_key": api_key}
+        if model:
+            kwargs["model"] = model
+        return AnthropicProvider(**kwargs)
+    elif provider_name == "openai":
+        kwargs = {"api_key": api_key}
+        if model:
+            kwargs["model"] = model
+        return OpenAIProvider(**kwargs)
+    else:
+        raise ValueError(
+            f"Unknown provider: {provider_name}. "
+            "Supported providers: anthropic, openai"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = {text = "MIT"}
 authors = [
     {name = "Dennis Somerville"}
 ]
-keywords = ["pdf", "markdown", "converter", "llm", "claude", "anthropic"]
+keywords = ["pdf", "markdown", "converter", "llm", "ai", "anthropic", "openai"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "anthropic>=0.46.0",
+    "openai>=1.0.0",
     "click>=8.3.0",
     "pymupdf>=1.26.4",
     "python-dotenv>=1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -225,12 +225,32 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/dd/4d4d46a06943e37c95b6e388237e1e38d1e9aab264ff070f86345d60b7a4/openai-2.1.0.tar.gz", hash = "sha256:47f3463a5047340a989b4c0cd5378054acfca966ff61a96553b22f098e3270a2", size = 572998, upload-time = "2025-10-02T20:43:15.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/83/88f64fc8f037885efa8a629d1215f5bc1f037453bab4d4f823b5533319eb/openai-2.1.0-py3-none-any.whl", hash = "sha256:33172e8c06a4576144ba4137a493807a9ca427421dcabc54ad3aa656daf757d3", size = 964939, upload-time = "2025-10-02T20:43:13.568Z" },
+]
+
+[[package]]
 name = "pdf-to-md-llm"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
+    { name = "openai" },
     { name = "pymupdf" },
     { name = "python-dotenv" },
 ]
@@ -239,6 +259,7 @@ dependencies = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.46.0" },
     { name = "click", specifier = ">=8.3.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "pymupdf", specifier = ">=1.26.4" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
@@ -376,6 +397,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enhance the PDF to Markdown converter to support both Anthropic and OpenAI AI providers, improving functionality and flexibility. Remove unnecessary notes and update dependencies accordingly.