### PR TITLE
Add models command to list available AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,26 @@ pdf-to-md-llm --help
 # Show help for specific commands
 pdf-to-md-llm convert --help
 pdf-to-md-llm batch --help
+pdf-to-md-llm models --help
 ```
+
+### List Available Models
+
+Check which AI models are available from your configured providers:
+
+```bash
+# List all available models from all configured providers
+pdf-to-md-llm models
+
+# List models from a specific provider
+pdf-to-md-llm models --provider anthropic
+pdf-to-md-llm models --provider openai
+```
+
+The `models` command will:
+- Show available models from providers that have API keys configured
+- Display the default model for each provider
+- Only query providers with valid API keys in your environment
 
 ## Using as a Python Library
 

--- a/pdf_to_md_llm/providers.py
+++ b/pdf_to_md_llm/providers.py
@@ -54,6 +54,16 @@ class AIProvider(ABC):
         """
         pass
 
+    @abstractmethod
+    def list_available_models(self) -> List[Dict[str, Any]]:
+        """
+        List available models from this provider.
+
+        Returns:
+            List of dicts with model information (id, name, etc.)
+        """
+        pass
+
 
 class AnthropicProvider(AIProvider):
     """Anthropic (Claude) AI provider"""
@@ -187,6 +197,31 @@ Output ONLY the markdown - no explanations or commentary.
         """Validate Anthropic API key"""
         return bool(self.api_key and self.api_key != "your-api-key-here")
 
+    def list_available_models(self) -> List[Dict[str, Any]]:
+        """List available models from Anthropic"""
+        try:
+            # Query the Anthropic API for available models
+            models = self.client.models.list()
+
+            # Convert to list of dicts with relevant info
+            model_list = []
+            for model in models.data:
+                model_list.append({
+                    'id': model.id,
+                    'name': model.display_name if hasattr(model, 'display_name') else model.id,
+                    'created': model.created_at if hasattr(model, 'created_at') else None
+                })
+
+            return model_list
+        except Exception:
+            # If API call fails, return a static list of known models
+            return [
+                {'id': 'claude-sonnet-4-20250514', 'name': 'Claude Sonnet 4', 'created': None},
+                {'id': 'claude-opus-4-20250514', 'name': 'Claude Opus 4', 'created': None},
+                {'id': 'claude-3-5-sonnet-20241022', 'name': 'Claude 3.5 Sonnet', 'created': None},
+                {'id': 'claude-3-5-haiku-20241022', 'name': 'Claude 3.5 Haiku', 'created': None},
+            ]
+
 
 class OpenAIProvider(AIProvider):
     """OpenAI (GPT) AI provider"""
@@ -318,6 +353,37 @@ Output ONLY the markdown - no explanations or commentary.
         """Validate OpenAI API key"""
         return bool(self.api_key and self.api_key != "your-api-key-here")
 
+    def list_available_models(self) -> List[Dict[str, Any]]:
+        """List available models from OpenAI"""
+        try:
+            # Query the OpenAI API for available models
+            models = self.client.models.list()
+
+            # Filter for GPT models and convert to list of dicts
+            model_list = []
+            for model in models.data:
+                # Only include GPT models (filter out embedding models, etc.)
+                if 'gpt' in model.id.lower():
+                    model_list.append({
+                        'id': model.id,
+                        'name': model.id,
+                        'created': model.created if hasattr(model, 'created') else None
+                    })
+
+            # Sort by creation date (newest first)
+            model_list.sort(key=lambda x: x['created'] if x['created'] else 0, reverse=True)
+
+            return model_list
+        except Exception:
+            # If API call fails, return a static list of known models
+            return [
+                {'id': 'gpt-4o', 'name': 'gpt-4o', 'created': None},
+                {'id': 'gpt-4o-mini', 'name': 'gpt-4o-mini', 'created': None},
+                {'id': 'gpt-4-turbo', 'name': 'gpt-4-turbo', 'created': None},
+                {'id': 'gpt-4', 'name': 'gpt-4', 'created': None},
+                {'id': 'gpt-3.5-turbo', 'name': 'gpt-3.5-turbo', 'created': None},
+            ]
+
 
 def validate_api_key_available(
     provider: str,
@@ -420,3 +486,82 @@ def get_provider(
             f"Unknown provider: {provider_name}. "
             "Supported providers: anthropic, openai"
         )
+
+
+def list_models_for_providers(
+    provider_filter: Optional[str] = None
+) -> Dict[str, Dict[str, Any]]:
+    """
+    List available models from all providers (or a specific provider).
+
+    Only queries providers for which API keys are available.
+
+    Args:
+        provider_filter: Optional provider name to filter by ('anthropic' or 'openai')
+
+    Returns:
+        Dict mapping provider names to their data:
+        {
+            'anthropic': {
+                'available': True/False,
+                'default_model': 'model-id',
+                'models': [{'id': '...', 'name': '...', ...}]
+            },
+            'openai': {...}
+        }
+    """
+    result = {}
+
+    # Define providers to check
+    providers_to_check = {
+        'anthropic': AnthropicProvider,
+        'openai': OpenAIProvider
+    }
+
+    # Filter if requested
+    if provider_filter:
+        provider_filter = provider_filter.lower()
+        if provider_filter not in providers_to_check:
+            raise ValueError(
+                f"Unknown provider: {provider_filter}. "
+                "Supported providers: anthropic, openai"
+            )
+        providers_to_check = {provider_filter: providers_to_check[provider_filter]}
+
+    # Check each provider
+    for provider_name, provider_class in providers_to_check.items():
+        # Check if API key is available
+        is_valid, _ = validate_api_key_available(provider_name)
+
+        if is_valid:
+            try:
+                # Initialize provider and get models
+                provider = provider_class()
+
+                # Get default model from provider instance
+                default_model = provider.model
+
+                # Get available models
+                models = provider.list_available_models()
+
+                result[provider_name] = {
+                    'available': True,
+                    'default_model': default_model,
+                    'models': models
+                }
+            except Exception as e:
+                # Provider initialization failed
+                result[provider_name] = {
+                    'available': False,
+                    'error': str(e),
+                    'models': []
+                }
+        else:
+            # No API key available
+            result[provider_name] = {
+                'available': False,
+                'error': 'API key not found',
+                'models': []
+            }
+
+    return result

--- a/pdf_to_md_llm/providers.py
+++ b/pdf_to_md_llm/providers.py
@@ -199,28 +199,19 @@ Output ONLY the markdown - no explanations or commentary.
 
     def list_available_models(self) -> List[Dict[str, Any]]:
         """List available models from Anthropic"""
-        try:
-            # Query the Anthropic API for available models
-            models = self.client.models.list()
+        # Query the Anthropic API for available models
+        models = self.client.models.list()
 
-            # Convert to list of dicts with relevant info
-            model_list = []
-            for model in models.data:
-                model_list.append({
-                    'id': model.id,
-                    'name': model.display_name if hasattr(model, 'display_name') else model.id,
-                    'created': model.created_at if hasattr(model, 'created_at') else None
-                })
+        # Convert to list of dicts with relevant info
+        model_list = []
+        for model in models.data:
+            model_list.append({
+                'id': model.id,
+                'name': model.display_name if hasattr(model, 'display_name') else model.id,
+                'created': model.created_at if hasattr(model, 'created_at') else None
+            })
 
-            return model_list
-        except Exception:
-            # If API call fails, return a static list of known models
-            return [
-                {'id': 'claude-sonnet-4-20250514', 'name': 'Claude Sonnet 4', 'created': None},
-                {'id': 'claude-opus-4-20250514', 'name': 'Claude Opus 4', 'created': None},
-                {'id': 'claude-3-5-sonnet-20241022', 'name': 'Claude 3.5 Sonnet', 'created': None},
-                {'id': 'claude-3-5-haiku-20241022', 'name': 'Claude 3.5 Haiku', 'created': None},
-            ]
+        return model_list
 
 
 class OpenAIProvider(AIProvider):
@@ -355,34 +346,24 @@ Output ONLY the markdown - no explanations or commentary.
 
     def list_available_models(self) -> List[Dict[str, Any]]:
         """List available models from OpenAI"""
-        try:
-            # Query the OpenAI API for available models
-            models = self.client.models.list()
+        # Query the OpenAI API for available models
+        models = self.client.models.list()
 
-            # Filter for GPT models and convert to list of dicts
-            model_list = []
-            for model in models.data:
-                # Only include GPT models (filter out embedding models, etc.)
-                if 'gpt' in model.id.lower():
-                    model_list.append({
-                        'id': model.id,
-                        'name': model.id,
-                        'created': model.created if hasattr(model, 'created') else None
-                    })
+        # Filter for GPT models and convert to list of dicts
+        model_list = []
+        for model in models.data:
+            # Only include GPT models (filter out embedding models, etc.)
+            if 'gpt' in model.id.lower():
+                model_list.append({
+                    'id': model.id,
+                    'name': model.id,
+                    'created': model.created if hasattr(model, 'created') else None
+                })
 
-            # Sort by creation date (newest first)
-            model_list.sort(key=lambda x: x['created'] if x['created'] else 0, reverse=True)
+        # Sort by creation date (newest first)
+        model_list.sort(key=lambda x: x['created'] if x['created'] else 0, reverse=True)
 
-            return model_list
-        except Exception:
-            # If API call fails, return a static list of known models
-            return [
-                {'id': 'gpt-4o', 'name': 'gpt-4o', 'created': None},
-                {'id': 'gpt-4o-mini', 'name': 'gpt-4o-mini', 'created': None},
-                {'id': 'gpt-4-turbo', 'name': 'gpt-4-turbo', 'created': None},
-                {'id': 'gpt-4', 'name': 'gpt-4', 'created': None},
-                {'id': 'gpt-3.5-turbo', 'name': 'gpt-3.5-turbo', 'created': None},
-            ]
+        return model_list
 
 
 def validate_api_key_available(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-to-md-llm"
-version = "1.0.5"
+version = "1.1.0"
 description = "Convert PDF documents to clean Markdown using Claude API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "pdf-to-md-llm"
-version = "1.0.5"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Implements a new CLI subcommand to list available models from Anthropic and OpenAI providers.

This resolves issue #10 by adding a `models` command that:
- Queries provider APIs to list available models when API keys are configured
- Organizes models by provider (Anthropic/OpenAI)
- Highlights the default model for each provider
- Allows filtering by specific provider with `--provider` option
- Only queries providers with valid API keys
- Provides clear, helpful error messages when API calls fail (invalid keys, network issues, etc.)

## Changes
- Added `list_available_models()` abstract method to `AIProvider` class
- Implemented model listing for `AnthropicProvider` and `OpenAIProvider`
- Added `list_models_for_providers()` helper function to coordinate multi-provider listing
- Created new `models` CLI command with optional `--provider` filter
- Improved error handling to show actionable messages instead of fake fallback data

## Usage Examples
```bash
# List all available models
pdf-to-md-llm models

# List only Anthropic models
pdf-to-md-llm models --provider anthropic

# List only OpenAI models
pdf-to-md-llm models --provider openai
```

## Output Example
```
Available Models:

Anthropic (Claude):
  • claude-sonnet-4-5-20250929
  • claude-opus-4-1-20250805
  • claude-sonnet-4-20250514 (default)
  • claude-3-5-sonnet-20241022
  ...

OpenAI (GPT):
  • gpt-4o (default)
  • gpt-4o-mini
  • gpt-4-turbo
  ...
```

## Error Handling
When API calls fail, users get helpful error messages:
```
Failed to list models:

Anthropic (Claude):
  Error code: 401 - authentication_error

  Your API key appears to be invalid. Please check:
  - The ANTHROPIC_API_KEY environment variable
  - Get a valid key at:
    https://console.anthropic.com/settings/keys
```

## Test Plan
- [x] Test `pdf-to-md-llm models` with both API keys configured
- [x] Test `pdf-to-md-llm models --provider anthropic`
- [x] Test `pdf-to-md-llm models --provider openai`
- [x] Verify command appears in main help
- [x] Verify default models are marked correctly
- [x] Test graceful handling when no API keys configured
- [x] Test clear error messages with invalid API keys
- [x] Verify no misleading fallback data is shown

Closes #10