### PR TITLE
Add multithreading support to batch convert command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ pdf-to-md-llm convert document.pdf --provider openai --model gpt-4o-mini
 Convert entire folders of PDFs:
 
 ```bash
-# Convert all PDFs in a folder
+# Convert all PDFs in a folder (single-threaded)
 pdf-to-md-llm batch ./research-papers
 
 # With custom output folder and vision mode
@@ -147,7 +147,22 @@ pdf-to-md-llm batch ./input-pdfs ./output-markdown --vision
 
 # Batch with OpenAI
 pdf-to-md-llm batch ./pdfs --provider openai --vision
+
+# Use multithreading for faster batch conversion (2 threads)
+pdf-to-md-llm batch ./pdfs --threads 2 --vision
+
+# Use 4 threads for even faster processing
+pdf-to-md-llm batch ./pdfs --threads 4 --vision
+
+# Maximum parallelization (be mindful of API rate limits)
+pdf-to-md-llm batch ./large-batch --threads 8
 ```
+
+**Multithreading Benefits:**
+- Dramatically reduces total conversion time for large batches
+- Efficiently utilizes multi-core processors
+- Thread count can be adjusted based on system resources and API rate limits
+- Default is single-threaded (1 thread) to avoid rate limit issues
 
 ### Scenario 6: Simple Text Documents
 
@@ -233,6 +248,16 @@ batch_convert(
     output_folder="./markdown",  # Optional
     provider="anthropic",
     use_vision=True,
+    verbose=True
+)
+
+# Batch convert with multithreading for faster processing
+batch_convert(
+    input_folder="./pdfs",
+    output_folder="./markdown",
+    provider="anthropic",
+    use_vision=True,
+    threads=4,  # Use 4 threads for parallel processing
     verbose=True
 )
 ```
@@ -427,7 +452,8 @@ def batch_convert(
     max_tokens: int = 4000,
     verbose: bool = True,
     use_vision: bool = False,
-    vision_dpi: int = 150
+    vision_dpi: int = 150,
+    threads: int = 1
 ) -> None
 ```
 
@@ -436,7 +462,14 @@ Convert all PDFs in a folder to markdown.
 **Parameters:**
 - `input_folder`: Folder containing PDF files
 - `output_folder`: Optional output folder (defaults to input folder)
+- `threads`: Number of threads for parallel processing (default: 1 for single-threaded)
 - All other parameters same as `convert_pdf_to_markdown()`
+
+**Note on Multithreading:**
+- Single-threaded (`threads=1`): Default, sequential processing
+- Multithreaded (`threads>1`): Parallel processing for faster batch conversion
+- Be mindful of API rate limits when using higher thread counts
+- Progress output is simplified in multithreaded mode for clarity
 
 #### `extract_text_from_pdf()`
 

--- a/pdf_to_md_llm/__init__.py
+++ b/pdf_to_md_llm/__init__.py
@@ -17,6 +17,7 @@ from .converter import (
     DEFAULT_PAGES_PER_CHUNK,
     DEFAULT_VISION_DPI,
     DEFAULT_VISION_PAGES_PER_CHUNK,
+    DEFAULT_THREADS,
 )
 from .providers import (
     AIProvider,
@@ -40,6 +41,7 @@ __all__ = [
     "DEFAULT_PAGES_PER_CHUNK",
     "DEFAULT_VISION_DPI",
     "DEFAULT_VISION_PAGES_PER_CHUNK",
+    "DEFAULT_THREADS",
     "CONVERSION_PROMPT",
     "VISION_CONVERSION_PROMPT",
     "AIProvider",

--- a/pdf_to_md_llm/cli.py
+++ b/pdf_to_md_llm/cli.py
@@ -12,7 +12,8 @@ from .converter import (
     batch_convert,
     DEFAULT_PAGES_PER_CHUNK,
     DEFAULT_PROVIDER,
-    DEFAULT_VISION_DPI
+    DEFAULT_VISION_DPI,
+    DEFAULT_THREADS
 )
 from .providers import validate_api_key_available, list_models_for_providers
 
@@ -250,10 +251,12 @@ def models(provider):
 @cli.command()
 @click.argument('input_folder', type=click.Path(exists=True, file_okay=False))
 @click.argument('output_folder', type=click.Path(), required=False)
+@click.option('--threads', type=int, default=DEFAULT_THREADS,
+              help=f'Number of threads for parallel processing (default: {DEFAULT_THREADS}). Use 2+ for faster batch conversion.')
 @vision_options
 @chunking_options
 @provider_options
-def batch(input_folder, output_folder, provider, model, api_key, pages_per_chunk, vision, vision_dpi, vision_pages_per_chunk):
+def batch(input_folder, output_folder, threads, provider, model, api_key, pages_per_chunk, vision, vision_dpi, vision_pages_per_chunk):
     """Convert all PDF files in a folder to markdown.
 
     INPUT_FOLDER: Folder containing PDF files
@@ -263,6 +266,9 @@ def batch(input_folder, output_folder, provider, model, api_key, pages_per_chunk
     Vision mode provides significantly better results for documents with complex layouts,
     tables, charts, or multi-column formats. It uses ~2-3x more tokens but delivers
     superior quality.
+
+    Use --threads to enable parallel processing for faster batch conversion. Note that
+    higher thread counts may increase API rate limit risks.
     """
     # Validate API key is available before processing
     validate_provider_or_abort(provider, api_key)
@@ -278,7 +284,8 @@ def batch(input_folder, output_folder, provider, model, api_key, pages_per_chunk
         api_key=api_key,
         model=model,
         use_vision=vision,
-        vision_dpi=vision_dpi
+        vision_dpi=vision_dpi,
+        threads=threads
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-to-md-llm"
-version = "2.0.2"
+version = "2.1.0"
 description = "Library and CLI to convert PDF documents to clean, well-structured Markdown using LLM-assisted processing, leveraging Antrhopic and OpenAI models for intelligent extraction of text, tables, and complex layouts."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "pdf-to-md-llm"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

This PR implements #16 by adding multithreading support to the `batch` command, enabling parallel processing of multiple PDF files for significantly faster batch conversions.

## Changes

### Core Implementation
- **[converter.py](https://github.com/densom/pdf-to-md-llm/blob/16-add-multithreading-to-batch-convert/pdf_to_md_llm/converter.py)**
  - Added `DEFAULT_THREADS = 1` constant
  - Imported `ThreadPoolExecutor` and `threading` for parallel processing
  - Updated `batch_convert()` to accept `threads` parameter
  - Implemented dual-mode execution:
    - Single-threaded (`threads=1`): Original behavior with detailed progress
    - Multithreaded (`threads>1`): Parallel processing with simplified output
  - Added thread-safe progress tracking with locks
  - Added batch configuration display (provider, model, vision mode, thread count)

### CLI Enhancement
- **[cli.py](https://github.com/densom/pdf-to-md-llm/blob/16-add-multithreading-to-batch-convert/pdf_to_md_llm/cli.py)**
  - Added `--threads` option to `batch` command (default: 1)
  - Updated help text with usage guidance and rate limit warnings

### Library API
- **[__init__.py](https://github.com/densom/pdf-to-md-llm/blob/16-add-multithreading-to-batch-convert/pdf_to_md_llm/__init__.py)**
  - Exported `DEFAULT_THREADS` for library users

### Documentation
- **[README.md](https://github.com/densom/pdf-to-md-llm/blob/16-add-multithreading-to-batch-convert/README.md)**
  - Added multithreading examples in Scenario 5
  - Documented benefits and considerations
  - Updated Python library usage examples
  - Enhanced API Reference with `threads` parameter

## Usage Examples

### CLI
```bash
# Single-threaded (default, backward compatible)
pdf-to-md-llm batch ./pdfs

# Use 2 threads for faster processing
pdf-to-md-llm batch ./pdfs --threads 2 --vision

# Use 4 threads for maximum speed
pdf-to-md-llm batch ./pdfs --threads 4 --vision
```

### Python Library
```python
from pdf_to_md_llm import batch_convert

# Multithreaded batch conversion
batch_convert(
    input_folder="./pdfs",
    output_folder="./markdown",
    provider="anthropic",
    use_vision=True,
    threads=4
)
```

## Sample Output

### Multithreaded Mode (3 threads)
```
Batch Processing Configuration:
  Provider: anthropic
  Model: claude-3-5-haiku-20241022
  Vision mode: disabled
  Mode: multithreaded (3 threads)
  Files: 6 PDF files

[OK] [1/6] basic-text - Copy (2).pdf
[OK] [2/6] basic-text - Copy (3).pdf
[OK] [3/6] basic-text - Copy (4).pdf
[OK] [4/6] basic-text - Copy.pdf
[OK] [5/6] basic-text.pdf
[OK] [6/6] basic-text - Copy (5).pdf

Batch conversion complete!
  Output directory: input
```

## Key Features

✅ **Backward Compatible**: Default remains single-threaded  
✅ **Flexible**: Configurable thread count for any workload  
✅ **Thread-Safe**: Proper synchronization for progress tracking  
✅ **Error Resilient**: Errors in one thread don't affect others  
✅ **Clear Output**: Clean, informative progress display  
✅ **Configuration Display**: Shows provider, model, and mode upfront  
✅ **Cross-Platform**: Uses ASCII status indicators for Windows compatibility

## Testing

Tested successfully with:
- Single-threaded mode (preserves original behavior)
- 2, 3, and 4 thread configurations
- Vision mode enabled/disabled
- Multiple PDF files in batch
- Error handling and progress tracking

## Benefits

- **Performance**: Dramatically reduces total conversion time for large batches
- **Resource Utilization**: Better use of modern multi-core processors
- **Flexibility**: Thread count adjustable based on system resources and API rate limits
- **Transparency**: Clear display of processing configuration upfront

## Notes

- Default is single-threaded to avoid API rate limit issues
- Users should be mindful of their provider's rate limits when using higher thread counts
- Progress output is simplified in multithreaded mode for clarity
- Uses `ThreadPoolExecutor` (optimal for I/O-bound API operations)

Closes #16