### PR TITLE
Add --version CLI option to display tool version

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ pdf-to-md-llm convert simple-doc.pdf --pages-per-chunk 10
 ### Getting Help
 
 ```bash
+# Check the installed version
+pdf-to-md-llm --version
+
 # Show all available options
 pdf-to-md-llm --help
 

--- a/pdf_to_md_llm/cli.py
+++ b/pdf_to_md_llm/cli.py
@@ -90,8 +90,9 @@ def vision_options(f):
 
 
 @click.group(invoke_without_command=True)
+@click.option('--version', is_flag=True, help='Show version and exit')
 @click.pass_context
-def cli(ctx):
+def cli(ctx, version):
     """PDF to Markdown Converter (LLM-Assisted)
 
     Convert PDF documents to clean, well-structured Markdown using AI providers.
@@ -102,6 +103,16 @@ def cli(ctx):
     - ANTHROPIC_API_KEY for Anthropic/Claude
     - OPENAI_API_KEY for OpenAI/GPT
     """
+    # If --version flag is provided, show version and exit
+    if version:
+        from importlib.metadata import version as get_version
+        try:
+            pkg_version = get_version('pdf-to-md-llm')
+            click.echo(pkg_version)
+        except Exception:
+            click.echo('unknown', err=True)
+        ctx.exit()
+
     # If no subcommand is provided, show help
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-to-md-llm"
-version = "2.1.0"
+version = "2.2.0"
 description = "Library and CLI to convert PDF documents to clean, well-structured Markdown using LLM-assisted processing, leveraging Antrhopic and OpenAI models for intelligent extraction of text, tables, and complex layouts."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "pdf-to-md-llm"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Adds `--version` CLI option that outputs the current version of pdf-to-md-llm
- Version is read dynamically from package metadata using `importlib.metadata`
- Updated README.md with usage example

## Changes
- Added `--version` flag to main CLI group in [cli.py](pdf_to_md_llm/cli.py)
- Version is displayed using `importlib.metadata.version()` for automatic sync with pyproject.toml
- Updated "Getting Help" section in README.md
- Bumped version to 2.2.0

## Test plan
- [x] Verified `pdf-to-md-llm --version` outputs `2.2.0`
- [x] Verified `uv run pdf-to-md-llm --version` works correctly
- [x] Confirmed `--version` appears in `--help` output
- [x] Tested that all existing commands still work normally

Resolves #18